### PR TITLE
Fixed scrollbars not looking nice

### DIFF
--- a/stylesheets/atom.less
+++ b/stylesheets/atom.less
@@ -7,3 +7,21 @@
 .workspace {
   background-color: @app-background-color;
 }
+
+.scrollbars-visible-always {
+  ::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
+
+  ::-webkit-scrollbar-track,
+  ::-webkit-scrollbar-corner {
+    background: @scrollbar-background-color;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    background: @scrollbar-color;
+    border-radius: 5px;
+    box-shadow: 0 0 1px black inset;
+  }
+}

--- a/stylesheets/ui-variables.less
+++ b/stylesheets/ui-variables.less
@@ -60,6 +60,9 @@
 @tree-view-background-color: @tool-panel-background-color;
 @tree-view-border-color: @tool-panel-border-color;
 
+@scrollbar-background-color: rgba(42, 42, 42, 0.5);
+@scrollbar-color: rgba(92, 92, 92, 0.5);
+
 @ui-site-color-1: @background-color-success; // green
 @ui-site-color-2: @background-color-info; // blue
 @ui-site-color-3: @background-color-warning; // orange


### PR DESCRIPTION
The toolbars for this theme defaulted to a regular scrollbar look. I changed that so they now are the same as Atom's default look.
