### PR TITLE
Fixed scrollbar styling to work with Shadow DOM.

### DIFF
--- a/stylesheets/atom.less
+++ b/stylesheets/atom.less
@@ -1,7 +1,7 @@
 @import "ui-variables";
 
 * {
-	box-sizing: border-box;
+  box-sizing: border-box;
 }
 
 .workspace {
@@ -9,17 +9,17 @@
 }
 
 .scrollbars-visible-always {
-  ::-webkit-scrollbar {
+  /deep/ ::-webkit-scrollbar {
     width: 8px;
     height: 8px;
   }
 
-  ::-webkit-scrollbar-track,
-  ::-webkit-scrollbar-corner {
+  /deep/ ::-webkit-scrollbar-track,
+  /deep/ ::-webkit-scrollbar-corner {
     background: @scrollbar-background-color;
   }
 
-  ::-webkit-scrollbar-thumb {
+  /deep/ ::-webkit-scrollbar-thumb {
     background: @scrollbar-color;
     border-radius: 5px;
     box-shadow: 0 0 1px black inset;


### PR DESCRIPTION
Added /deep/ so the scrollbars would be styled again under the new Shadow DOM changes to Atom.

![scrollbar_fix](https://cloud.githubusercontent.com/assets/6563769/5748354/e07a6c34-9c04-11e4-8c40-86758e3c8eea.png)
