### PR TITLE
Improved the readability of atom text boxes

### DIFF
--- a/stylesheets/editor.less
+++ b/stylesheets/editor.less
@@ -4,7 +4,7 @@
 .editor.mini {
   color: @text-color-highlight;
   background-color: @input-background-color;
-  // border: 1px solid @input-border-color;
+  border: 1px solid @input-border-color;
   box-shadow:
     inset 0 1px 1px rgba(0, 0, 0, .075);
   border-radius: @component-border-radius;

--- a/stylesheets/ui-variables.less
+++ b/stylesheets/ui-variables.less
@@ -31,7 +31,7 @@
 @pane-item-background-color: @base-background-color;
 @pane-item-border-color: rgba(0, 0, 0, 0.5);
 
-@input-background-color: #303336;
+@input-background-color: #212224;
 @input-border-color: @base-border-color;
 
 @tool-panel-background-color: #1d1f21;


### PR DESCRIPTION
I uncommented the border CSS line and changed the background color to the Atom Dark value. At least for me, now they're much easier to read than before.